### PR TITLE
chore(readme): add a precautionary message recommending neovim v0.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ A Neovim utility plugin to find related context files for a file. Scan for [Proj
 
 ## Installation
 
+> ⚠️ **Warning**  
+> Neovim >= 0.11 is highly recommended to avoid any pattern matching issues (see [this issue](https://github.com/neovim/neovim/issues/28931) and [this PR](https://github.com/neovim/neovim/pull/29236))
+
 Using [lazy.nvim](https://github.com/folke/lazy.nvim)
 
 ```lua


### PR DESCRIPTION
Hey, first of all, great work on the plugin.

I've decided to add this small warning in the `Installation` paragraph (the most eye-catching one) that recommends upgrading to v0.11 (that was released today, yesterday I had to use nightly to be able to overcome this annoying issue) due to a PR that fixes the issue with overlapping group conditions that could cause some unexpected pattern matching errors for users (like me, for example, whose silly head spent more than an hour yesterday trying to debug why `*.{ts,tsx}` does not match `tsx` files in my project).

Basically, the issue was that when globs in the rule frontmatter are defined like e.g. `globs: ["apps/**/*.{ts,tsx}"]`, the latter won't match, if the strings overlap.

In v0.11 the upstream now contains the PR mentioned in the updated README and it fixes the problem.