### PR TITLE
fix: trimming lines before resolving glob

### DIFF
--- a/lua/contextfiles/core.lua
+++ b/lua/contextfiles/core.lua
@@ -76,7 +76,7 @@ local function parse_glob_patterns(content)
         in_frontmatter = true
       end
     elseif in_frontmatter then
-      local globs = line:match("^globs:%s*(.+)$")
+      local globs = line:gsub("^%s*(.-)%s*$", "%1"):match("^globs:%s*(.+)$")
       if globs then
         -- Handle array format: globs: ["pattern1", "pattern2"]
         if globs:match("^%[.+%]$") then


### PR DESCRIPTION
Sometimes rules might contain globs with some whitespace, e.g.:
`globs: `

In such case we want it to be treated as `globs:`.
